### PR TITLE
Improve I18N Issues (Based on 3.2.0)

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -8,15 +8,15 @@
 			<form method="post" class="form-horizontal">
 
 				<div class="page-header" style="margin-top: 0px;">
-					<h1 style="margin-top: 0px;"><?php esc_html_e( 'General Settings', 'wpsite-post-status-notification' ) ?></h1>
+					<h1 style="margin-top: 0px;"><?php esc_html_e( 'General Settings', 'wpsite-post-status-notifications' ) ?></h1>
 				</div>
 
 				<!-- Include these post types -->
 
 				<div class="form-group">
-					<label class="col-sm-3 control-label"><?php esc_html_e( 'Post Types', 'wpsite-post-status-notification' ) ?></label>
+					<label class="col-sm-3 control-label"><?php esc_html_e( 'Post Types', 'wpsite-post-status-notifications' ) ?></label>
 					<div class="col-sm-9">
-						<em class="help-block"><?php esc_html_e( 'Post status notification emails will only be sent for activity occurring within the following post types.', 'wpsite-post-status-notification' ) ?></em>
+						<em class="help-block"><?php esc_html_e( 'Post status notification emails will only be sent for activity occurring within the following post types.', 'wpsite-post-status-notifications' ) ?></em>
 						<?php foreach ( $post_types as $post_type ) { ?>
 							<input type="checkbox" id="wpsite_post_status_notifications_settings_post_types_<?php echo $post_type ?>" name="wpsite_post_status_notifications_settings_post_types_<?php echo $post_type ?>" <?php echo ( isset( $settings['post_types'] ) && in_array( $post_type, $settings['post_types'] ) ? 'checked="checked"' : '' ) ?>/><span><?php echo $post_type ?></span><br />
 						<?php } ?>
@@ -24,118 +24,118 @@
 				</div>
 
 				<div class="form-group">
-					<label class="col-sm-3 control-label"><?php esc_html_e( 'Share Links', 'wpsite-post-status-notification' ) ?></label>
+					<label class="col-sm-3 control-label"><?php esc_html_e( 'Share Links', 'wpsite-post-status-notifications' ) ?></label>
 					<div class="col-sm-9">
-						<em class="help-block"><?php esc_html_e( 'Encourage sharing of published posts by inserting automatically generated share links to the bottom of the email notifications that are sent.', 'wpsite-post-status-notification' ) ?></em>
+						<em class="help-block"><?php esc_html_e( 'Encourage sharing of published posts by inserting automatically generated share links to the bottom of the email notifications that are sent.', 'wpsite-post-status-notifications' ) ?></em>
 
-						<input id="wpsite_post_status_notifications_settings_message_share_links_twitter" name="wpsite_post_status_notifications_settings_message_share_links_twitter" type="checkbox" value="users" <?php echo isset( $settings['message']['share_links']['twitter'] ) && $settings['message']['share_links']['twitter'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'Twitter', 'wpsite-post-status-notification' ) ?></span><br />
+						<input id="wpsite_post_status_notifications_settings_message_share_links_twitter" name="wpsite_post_status_notifications_settings_message_share_links_twitter" type="checkbox" value="users" <?php echo isset( $settings['message']['share_links']['twitter'] ) && $settings['message']['share_links']['twitter'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'Twitter', 'wpsite-post-status-notifications' ) ?></span><br />
 
-						<input id="wpsite_post_status_notifications_settings_message_share_links_facebook" name="wpsite_post_status_notifications_settings_message_share_links_facebook" type="checkbox" value="users" <?php echo isset( $settings['message']['share_links']['facebook'] ) && $settings['message']['share_links']['facebook'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'Facebook', 'wpsite-post-status-notification' ) ?></span><br />
+						<input id="wpsite_post_status_notifications_settings_message_share_links_facebook" name="wpsite_post_status_notifications_settings_message_share_links_facebook" type="checkbox" value="users" <?php echo isset( $settings['message']['share_links']['facebook'] ) && $settings['message']['share_links']['facebook'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'Facebook', 'wpsite-post-status-notifications' ) ?></span><br />
 
-						<input id="wpsite_post_status_notifications_settings_message_share_links_linkedin" name="wpsite_post_status_notifications_settings_message_share_links_linkedin" type="checkbox" value="users" <?php echo isset( $settings['message']['share_links']['linkedin'] ) && $settings['message']['share_links']['linkedin'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'LinkedIn', 'wpsite-post-status-notification' ) ?></span><br />
+						<input id="wpsite_post_status_notifications_settings_message_share_links_linkedin" name="wpsite_post_status_notifications_settings_message_share_links_linkedin" type="checkbox" value="users" <?php echo isset( $settings['message']['share_links']['linkedin'] ) && $settings['message']['share_links']['linkedin'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'LinkedIn', 'wpsite-post-status-notifications' ) ?></span><br />
 					</div>
 				</div>
 
 				<div class="form-group">
-					<label class="col-sm-3 control-label"><?php esc_html_e( 'Post Submitted for Review', 'wpsite-post-status-notification' ) ?></label>
+					<label class="col-sm-3 control-label"><?php esc_html_e( 'Post Submitted for Review', 'wpsite-post-status-notifications' ) ?></label>
 					<div class="col-sm-9">
-						<em class="help-block"><?php esc_html_e( 'Notify these users when a contributor submits a post for review.', 'wpsite-post-status-notification' ) ?></em>
+						<em class="help-block"><?php esc_html_e( 'Notify these users when a contributor submits a post for review.', 'wpsite-post-status-notifications' ) ?></em>
 
-						<input name="wpsite_post_status_notifications_settings_pending_notify" type="radio" value="administrator" <?php echo isset( $settings['pending_notify'] ) && 'administrator' === $settings['pending_notify'] ? 'checked' : ''; ?>><span><?php esc_html_e( 'Admins', 'wpsite-post-status-notification' ) ?></span><br />
+						<input name="wpsite_post_status_notifications_settings_pending_notify" type="radio" value="administrator" <?php echo isset( $settings['pending_notify'] ) && 'administrator' === $settings['pending_notify'] ? 'checked' : ''; ?>><span><?php esc_html_e( 'Admins', 'wpsite-post-status-notifications' ) ?></span><br />
 
-						<input name="wpsite_post_status_notifications_settings_pending_notify" type="radio" value="editor" <?php echo isset( $settings['pending_notify'] ) && 'editor' === $settings['pending_notify'] ? 'checked' : ''; ?>><span><?php esc_html_e( 'Editors', 'wpsite-post-status-notification' ) ?></span><br />
+						<input name="wpsite_post_status_notifications_settings_pending_notify" type="radio" value="editor" <?php echo isset( $settings['pending_notify'] ) && 'editor' === $settings['pending_notify'] ? 'checked' : ''; ?>><span><?php esc_html_e( 'Editors', 'wpsite-post-status-notifications' ) ?></span><br />
 
-                        <input name="wpsite_post_status_notifications_settings_pending_notify" type="radio" value="both" <?php echo isset( $settings['pending_notify'] ) && 'both' === $settings['pending_notify'] ? 'checked' : ''; ?>><span><?php esc_html_e( 'Both Admins and Editors', 'wpsite-post-status-notification' ) ?></span><br />
+                        <input name="wpsite_post_status_notifications_settings_pending_notify" type="radio" value="both" <?php echo isset( $settings['pending_notify'] ) && 'both' === $settings['pending_notify'] ? 'checked' : ''; ?>><span><?php esc_html_e( 'Both Admins and Editors', 'wpsite-post-status-notifications' ) ?></span><br />
 					</div>
 				</div>
 
 				<div class="form-group">
-					<label class="col-sm-3 control-label"><?php esc_html_e( 'Post Was Published', 'wpsite-post-status-notification' ) ?></label>
+					<label class="col-sm-3 control-label"><?php esc_html_e( 'Post Was Published', 'wpsite-post-status-notifications' ) ?></label>
 					<div class="col-sm-9">
-						<em class="help-block"><?php esc_html_e( 'Notify these users when a contributor\'s post is published or any other post is published.', 'wpsite-post-status-notification' ) ?></em>
+						<em class="help-block"><?php esc_html_e( 'Notify these users when a contributor\'s post is published or any other post is published.', 'wpsite-post-status-notifications' ) ?></em>
 
-						<input id="wpsite_post_status_notifications_settings_publish_notify_author" name="wpsite_post_status_notifications_settings_publish_notify" type="radio" value="author" <?php echo isset( $settings['publish_notify'] ) && 'author' === $settings['publish_notify'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'Contributors', 'wpsite-post-status-notification' ) ?></span><br />
+						<input id="wpsite_post_status_notifications_settings_publish_notify_author" name="wpsite_post_status_notifications_settings_publish_notify" type="radio" value="author" <?php echo isset( $settings['publish_notify'] ) && 'author' === $settings['publish_notify'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'Contributors', 'wpsite-post-status-notifications' ) ?></span><br />
 
-						<input id="wpsite_post_status_notifications_settings_publish_notify_users" name="wpsite_post_status_notifications_settings_publish_notify" type="radio" value="users" <?php echo isset( $settings['publish_notify'] ) && 'users' === $settings['publish_notify'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'All Users', 'wpsite-post-status-notification' ) ?></span><br />
+						<input id="wpsite_post_status_notifications_settings_publish_notify_users" name="wpsite_post_status_notifications_settings_publish_notify" type="radio" value="users" <?php echo isset( $settings['publish_notify'] ) && 'users' === $settings['publish_notify'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'All Users', 'wpsite-post-status-notifications' ) ?></span><br />
 
-						<input id="wpsite_post_status_notifications_settings_publish_notify_admins" name="wpsite_post_status_notifications_settings_publish_notify" type="radio" value="admins" <?php echo isset( $settings['publish_notify'] ) && 'admins' === $settings['publish_notify'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'Admins', 'wpsite-post-status-notification' ) ?></span><br />
+						<input id="wpsite_post_status_notifications_settings_publish_notify_admins" name="wpsite_post_status_notifications_settings_publish_notify" type="radio" value="admins" <?php echo isset( $settings['publish_notify'] ) && 'admins' === $settings['publish_notify'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'Admins', 'wpsite-post-status-notifications' ) ?></span><br />
 
-						<input id="wpsite_post_status_notifications_settings_publish_notify_editors" name="wpsite_post_status_notifications_settings_publish_notify" type="radio" value="editors" <?php echo isset( $settings['publish_notify'] ) && 'editors' === $settings['publish_notify'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'Editors', 'wpsite-post-status-notification' ) ?></span><br />
+						<input id="wpsite_post_status_notifications_settings_publish_notify_editors" name="wpsite_post_status_notifications_settings_publish_notify" type="radio" value="editors" <?php echo isset( $settings['publish_notify'] ) && 'editors' === $settings['publish_notify'] ? 'checked="checked"' : ''; ?>><span><?php esc_html_e( 'Editors', 'wpsite-post-status-notifications' ) ?></span><br />
 
 					</div>
 				</div>
 
 				<div class="page-header">
-					<h1><?php esc_html_e( 'Email Headers', 'wpsite-post-status-notification' ) ?></h1>
+					<h1><?php esc_html_e( 'Email Headers', 'wpsite-post-status-notifications' ) ?></h1>
 				</div>
 
 				<!-- From -->
 
 				<div class="form-group">
-					<label class="col-sm-3 control-label"><?php esc_html_e( 'From', 'wpsite-post-status-notification' ) ?></label>
+					<label class="col-sm-3 control-label"><?php esc_html_e( 'From', 'wpsite-post-status-notifications' ) ?></label>
 					<div class="col-sm-9">
 						<input id="wpsite_post_status_notifications_settings_message_from_name" name="wpsite_post_status_notifications_settings_message_from_name" type="text" class="form-control" value="<?php echo ( isset( $settings['message']['from_name'] ) ? esc_attr( $settings['message']['from_name'] ) : get_bloginfo('name')); ?>" placeholder="<?php esc_html_e( 'My Website Name or My Company Name' ) ?>">
-						<em class="help-block"><?php esc_html_e( 'The From email address for all email notifications.  Please enter in emails separated by commas.', 'wpsite-post-status-notification' ) ?></em>
-						<input id="wpsite_post_status_notifications_settings_message_from_email" name="wpsite_post_status_notifications_settings_message_from_email" type="text" class="form-control" value="<?php echo ( isset( $settings['message']['from_email'] ) ? esc_attr( $settings['message']['from_email'] ) : 'wordpress@' . get_site_url()); ?>" placeholder="<?php esc_html_e( 'email@example.com or email@example.com,another@example.com', 'wpsite-post-status-notification' ) ?>">
-						<em class="help-block"><?php esc_html_e( 'The From email address for all email notifications.  Please enter in emails separated by commas.', 'wpsite-post-status-notification' ) ?></em>
+						<em class="help-block"><?php esc_html_e( 'The From email address for all email notifications.  Please enter in emails separated by commas.', 'wpsite-post-status-notifications' ) ?></em>
+						<input id="wpsite_post_status_notifications_settings_message_from_email" name="wpsite_post_status_notifications_settings_message_from_email" type="text" class="form-control" value="<?php echo ( isset( $settings['message']['from_email'] ) ? esc_attr( $settings['message']['from_email'] ) : 'wordpress@' . get_site_url()); ?>" placeholder="<?php esc_html_e( 'email@example.com or email@example.com,another@example.com', 'wpsite-post-status-notifications' ) ?>">
+						<em class="help-block"><?php esc_html_e( 'The From email address for all email notifications.  Please enter in emails separated by commas.', 'wpsite-post-status-notifications' ) ?></em>
 					</div>
 				</div>
 
 				<!-- Cc -->
 
 				<div class="form-group">
-					<label class="col-sm-3 control-label"><?php esc_html_e( 'Cc', 'wpsite-post-status-notification' ) ?></label>
+					<label class="col-sm-3 control-label"><?php esc_html_e( 'Cc', 'wpsite-post-status-notifications' ) ?></label>
 					<div class="col-sm-9">
-						<input id="wpsite_post_status_notifications_settings_message_cc_email" name="wpsite_post_status_notifications_settings_message_cc_email" type="text" class="form-control" value="<?php echo esc_attr( $settings['message']['cc_email'] ) ?>" placeholder="<?php esc_html_e( 'email@example.com or email@example.com,another@example.com', 'wpsite-post-status-notification' ) ?>">
-						<em class="help-block"><?php esc_html_e( 'The Cc email address for all email notifications.  Please enter in emails separated by commas.', 'wpsite-post-status-notification' ) ?></em>
+						<input id="wpsite_post_status_notifications_settings_message_cc_email" name="wpsite_post_status_notifications_settings_message_cc_email" type="text" class="form-control" value="<?php echo esc_attr( $settings['message']['cc_email'] ) ?>" placeholder="<?php esc_html_e( 'email@example.com or email@example.com,another@example.com', 'wpsite-post-status-notifications' ) ?>">
+						<em class="help-block"><?php esc_html_e( 'The Cc email address for all email notifications.  Please enter in emails separated by commas.', 'wpsite-post-status-notifications' ) ?></em>
 					</div>
 				</div>
 
 				<!-- Bcc -->
 
 				<div class="form-group">
-					<label class="col-sm-3 control-label"><?php esc_html_e( 'Bcc', 'wpsite-post-status-notification' ) ?></label>
+					<label class="col-sm-3 control-label"><?php esc_html_e( 'Bcc', 'wpsite-post-status-notifications' ) ?></label>
 					<div class="col-sm-9">
-						<input id="wpsite_post_status_notifications_settings_message_bcc_email" name="wpsite_post_status_notifications_settings_message_bcc_email" type="text" class="form-control" value="<?php echo esc_attr( $settings['message']['bcc_email'] ) ?>" placeholder="<?php esc_html_e( 'email@example.com or email@example.com,another@example.com', 'wpsite-post-status-notification' ) ?>">
-						<em class="help-block"><?php esc_html_e( 'The Bcc email address for all email notifications.  Please enter in emails separated by commas.', 'wpsite-post-status-notification' ) ?></em>
+						<input id="wpsite_post_status_notifications_settings_message_bcc_email" name="wpsite_post_status_notifications_settings_message_bcc_email" type="text" class="form-control" value="<?php echo esc_attr( $settings['message']['bcc_email'] ) ?>" placeholder="<?php esc_html_e( 'email@example.com or email@example.com,another@example.com', 'wpsite-post-status-notifications' ) ?>">
+						<em class="help-block"><?php esc_html_e( 'The Bcc email address for all email notifications.  Please enter in emails separated by commas.', 'wpsite-post-status-notifications' ) ?></em>
 					</div>
 				</div>
 
 				<div class="page-header">
-					<h1><?php esc_html_e( 'Custom Emails, Subjects and Messages', 'wpsite-post-status-notification' ) ?></h1>
+					<h1><?php esc_html_e( 'Custom Emails, Subjects and Messages', 'wpsite-post-status-notifications' ) ?></h1>
 				</div>
 
 				<!-- Dynamic Fields Legend -->
 
 				<div class="form-group">
-					<label class="col-sm-3 control-label"><?php esc_html_e( 'Dynamic Fields Legend', 'wpsite-post-status-notification' ) ?></label>
+					<label class="col-sm-3 control-label"><?php esc_html_e( 'Dynamic Fields Legend', 'wpsite-post-status-notifications' ) ?></label>
 					<div class="col-sm-9">
 
 						<table class="table table-striped table-responsive">
 							<thead>
-								<th><?php esc_html_e( 'Placeholder', 'wpsite-post-status-notification' ) ?></th>
-								<th><?php esc_html_e( 'Description', 'wpsite-post-status-notification' ) ?></th>
+								<th><?php esc_html_e( 'Placeholder', 'wpsite-post-status-notifications' ) ?></th>
+								<th><?php esc_html_e( 'Description', 'wpsite-post-status-notifications' ) ?></th>
 							</thead>
 							<tbody>
 								<tr>
-									<td><?php esc_html_e( '{post_title}', 'wpsite-post-status-notification' ) ?></td>
-									<td><?php esc_html_e( 'The title of the post (i.e. Hello World!)', 'wpsite-post-status-notification' ) ?></td>
+									<td><?php esc_html_e( '{post_title}', 'wpsite-post-status-notifications' ) ?></td>
+									<td><?php esc_html_e( 'The title of the post (i.e. Hello World!)', 'wpsite-post-status-notifications' ) ?></td>
 								</tr>
 								<tr>
-									<td><?php esc_html_e( '{post_type}', 'wpsite-post-status-notification' ) ?></td>
-									<td><?php esc_html_e( 'The type of the post (i.e. post or page).', 'wpsite-post-status-notification' ) ?></td>
+									<td><?php esc_html_e( '{post_type}', 'wpsite-post-status-notifications' ) ?></td>
+									<td><?php esc_html_e( 'The type of the post (i.e. post or page).', 'wpsite-post-status-notifications' ) ?></td>
 								</tr>
 								<tr>
-									<td><?php esc_html_e( '{post_url}', 'wpsite-post-status-notification' ) ?></td>
-									<td><?php esc_html_e( 'The post\'s permalink (i.e. http://example.com/post-title)', 'wpsite-post-status-notification' ) ?></td>
+									<td><?php esc_html_e( '{post_url}', 'wpsite-post-status-notifications' ) ?></td>
+									<td><?php esc_html_e( 'The post\'s permalink (i.e. http://example.com/post-title)', 'wpsite-post-status-notifications' ) ?></td>
 								</tr>
 								<tr>
-									<td><?php esc_html_e( '{display_name}', 'wpsite-post-status-notification' ) ?></td>
-									<td><?php esc_html_e( 'The post author\'s display name (i.e. Bod Smith)', 'wpsite-post-status-notification' ) ?></td>
+									<td><?php esc_html_e( '{display_name}', 'wpsite-post-status-notifications' ) ?></td>
+									<td><?php esc_html_e( 'The post author\'s display name (i.e. Bod Smith)', 'wpsite-post-status-notifications' ) ?></td>
 								</tr>
 								<tr>
-									<td><?php esc_html_e( '{break_line}', 'wpsite-post-status-notification' ) ?></td>
-									<td><?php esc_html_e( 'A new line in the email, this is great for adding spaces between sentences.', 'wpsite-post-status-notification' ) ?></td>
+									<td><?php esc_html_e( '{break_line}', 'wpsite-post-status-notifications' ) ?></td>
+									<td><?php esc_html_e( 'A new line in the email, this is great for adding spaces between sentences.', 'wpsite-post-status-notifications' ) ?></td>
 								</tr>
 							</tbody>
 						</table>
@@ -145,13 +145,13 @@
 				<!-- Email when a post is published -->
 
 				<div class="form-group">
-					<label class="col-sm-3 control-label"><?php esc_html_e( 'Post Published', 'wpsite-post-status-notification' ) ?><br /><button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#post-published"><?php esc_html_e( 'Example Email', 'wpsite-post-status-notification' ) ?></button></label>
+					<label class="col-sm-3 control-label"><?php esc_html_e( 'Post Published', 'wpsite-post-status-notifications' ) ?><br /><button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#post-published"><?php esc_html_e( 'Example Email', 'wpsite-post-status-notifications' ) ?></button></label>
 					<div class="col-sm-9">
-						<p class="form-control-static"><em><?php esc_html_e( 'Sent to users when a post has been published.  If the post being published was written by a contributor then they will receive a custom email as seen below.', 'wpsite-post-status-notification' ) ?></em></p>
-						<label><?php esc_html_e( 'Subject', 'wpsite-post-status-notification' ) ?></label><br/>
+						<p class="form-control-static"><em><?php esc_html_e( 'Sent to users when a post has been published.  If the post being published was written by a contributor then they will receive a custom email as seen below.', 'wpsite-post-status-notifications' ) ?></em></p>
+						<label><?php esc_html_e( 'Subject', 'wpsite-post-status-notifications' ) ?></label><br/>
 						<input id="wpsite_post_status_notifications_settings_message_subject_published" name="wpsite_post_status_notifications_settings_message_subject_published" type="text" class="form-control" value="<?php echo esc_attr( $settings['message']['subject_published'] ) ?>"/><br/>
 
-						<label><?php esc_html_e( 'Content', 'wpsite-post-status-notification' ) ?></label><br/>
+						<label><?php esc_html_e( 'Content', 'wpsite-post-status-notifications' ) ?></label><br/>
 						<textarea rows="10" cols="50" class="form-control" id="wpsite_post_status_notifications_settings_message_content_published" name="wpsite_post_status_notifications_settings_message_content_published"><?php echo esc_attr( $settings['message']['content_published'] ) ?></textarea>
 					</div>
 				</div>
@@ -159,13 +159,13 @@
 				<!-- Email sent to contributor when their post is published -->
 
 				<div class="form-group">
-					<label class="col-sm-3 control-label"><?php esc_html_e( 'Contributor\'s Post Published', 'wpsite-post-status-notification' ) ?><br /><button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#post-published-contributor"><?php esc_html_e( 'Example Email', 'wpsite-post-status-notification' ) ?></button></label>
+					<label class="col-sm-3 control-label"><?php esc_html_e( 'Contributor\'s Post Published', 'wpsite-post-status-notifications' ) ?><br /><button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#post-published-contributor"><?php esc_html_e( 'Example Email', 'wpsite-post-status-notifications' ) ?></button></label>
 					<div class="col-sm-9">
-						<p class="form-control-static"><em><?php esc_html_e( 'Sent to the contributor when their post is published.', 'wpsite-post-status-notification' ) ?></em></p>
-						<label><?php esc_html_e( 'Subject', 'wpsite-post-status-notification' ) ?></label><br/>
+						<p class="form-control-static"><em><?php esc_html_e( 'Sent to the contributor when their post is published.', 'wpsite-post-status-notifications' ) ?></em></p>
+						<label><?php esc_html_e( 'Subject', 'wpsite-post-status-notifications' ) ?></label><br/>
 						<input id="wpsite_post_status_notifications_settings_message_subject_published_contributor" name="wpsite_post_status_notifications_settings_message_subject_published_contributor" type="text" class="form-control" value="<?php echo esc_attr( $settings['message']['subject_published_contributor'] ) ?>"/><br/>
 
-						<label><?php esc_html_e( 'Content', 'wpsite-post-status-notification' ) ?></label><br/>
+						<label><?php esc_html_e( 'Content', 'wpsite-post-status-notifications' ) ?></label><br/>
 						<textarea rows="10" cols="50" class="form-control" id="wpsite_post_status_notifications_settings_message_content_published_contributor" name="wpsite_post_status_notifications_settings_message_content_published_contributor"><?php echo esc_attr( $settings['message']['content_published_contributor'] ) ?></textarea>
 					</div>
 				</div>
@@ -173,13 +173,13 @@
 				<!-- Email sent to admin when contributor submits post for review -->
 
 				<div class="form-group">
-					<label class="col-sm-3 control-label"><?php esc_html_e( 'Post Submitted for Review', 'wpsite-post-status-notification' ) ?><br /><button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#submit-for-review"><?php esc_html_e( 'Example Email', 'wpsite-post-status-notification' ) ?></button></label>
+					<label class="col-sm-3 control-label"><?php esc_html_e( 'Post Submitted for Review', 'wpsite-post-status-notifications' ) ?><br /><button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#submit-for-review"><?php esc_html_e( 'Example Email', 'wpsite-post-status-notifications' ) ?></button></label>
 					<div class="col-sm-9">
-						<p class="form-control-static"><em><?php esc_html_e( 'Sent to admins or editors when a contributor submits a post for review.', 'wpsite-post-status-notification' ) ?></em></p>
-						<label><?php esc_html_e( 'Subject', 'wpsite-post-status-notification' ) ?></label><br/>
+						<p class="form-control-static"><em><?php esc_html_e( 'Sent to admins or editors when a contributor submits a post for review.', 'wpsite-post-status-notifications' ) ?></em></p>
+						<label><?php esc_html_e( 'Subject', 'wpsite-post-status-notifications' ) ?></label><br/>
 						<input id="wpsite_post_status_notifications_settings_message_subject_pending" name="wpsite_post_status_notifications_settings_message_subject_pending" type="text" class="form-control" value="<?php echo esc_attr( $settings['message']['subject_pending'] ) ?>"/><br/>
 
-						<label><?php esc_html_e( 'Content', 'wpsite-post-status-notification' ) ?></label><br/>
+						<label><?php esc_html_e( 'Content', 'wpsite-post-status-notifications' ) ?></label><br/>
 						<textarea rows="10" cols="50" class="form-control" id="wpsite_post_status_notifications_settings_message_content_pending" name="wpsite_post_status_notifications_settings_message_content_pending"><?php echo esc_attr( $settings['message']['content_pending'] ) ?></textarea>
 					</div>
 				</div>
@@ -187,7 +187,7 @@
 				<?php wp_nonce_field( 'wpsite_post_status_notifications_admin_settings' ) ?>
 
 				<p class="submit">
-					<input type="submit" name="submit" id="submit" class="btn btn-info" value="<?php esc_html_e( 'Save Changes', 'wpsite-post-status-notification' ) ?>">
+					<input type="submit" name="submit" id="submit" class="btn btn-info" value="<?php esc_html_e( 'Save Changes', 'wpsite-post-status-notifications' ) ?>">
 				</p>
 
 			</form>
@@ -197,13 +197,13 @@
 					<div class="modal-content">
 						<div class="modal-header">
 							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-							<h4 class="modal-title"><?php esc_html_e( 'Example Email', 'wpsite-post-status-notification' ) ?></h4>
+							<h4 class="modal-title"><?php esc_html_e( 'Example Email', 'wpsite-post-status-notifications' ) ?></h4>
 						</div>
 						<div class="modal-body">
 							<img style="width: 100%;" src="<?php echo wpsite_psn()->plugin_url() . 'img/post-published.png'; ?>"/>
 						</div>
 						<div class="modal-footer">
-							<button type="button" class="btn btn-default" data-dismiss="modal"><?php esc_html_e( 'Close', 'wpsite-post-status-notification' ) ?></button>
+							<button type="button" class="btn btn-default" data-dismiss="modal"><?php esc_html_e( 'Close', 'wpsite-post-status-notifications' ) ?></button>
 						</div>
 					</div>
 				</div>
@@ -214,13 +214,13 @@
 					<div class="modal-content">
 						<div class="modal-header">
 							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-							<h4 class="modal-title"><?php esc_html_e( 'Example Email', 'wpsite-post-status-notification' ) ?></h4>
+							<h4 class="modal-title"><?php esc_html_e( 'Example Email', 'wpsite-post-status-notifications' ) ?></h4>
 						</div>
 						<div class="modal-body">
 							<img style="width: 100%;" src="<?php echo wpsite_psn()->plugin_url() . 'img/post-published-contributor.png'; ?>"/>
 						</div>
 						<div class="modal-footer">
-							<button type="button" class="btn btn-default" data-dismiss="modal"><?php esc_html_e( 'Close', 'wpsite-post-status-notification' ) ?></button>
+							<button type="button" class="btn btn-default" data-dismiss="modal"><?php esc_html_e( 'Close', 'wpsite-post-status-notifications' ) ?></button>
 						</div>
 					</div>
 				</div>
@@ -231,13 +231,13 @@
 					<div class="modal-content">
 						<div class="modal-header">
 							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-							<h4 class="modal-title"><?php esc_html_e( 'Example Email', 'wpsite-post-status-notification' ) ?></h4>
+							<h4 class="modal-title"><?php esc_html_e( 'Example Email', 'wpsite-post-status-notifications' ) ?></h4>
 						</div>
 						<div class="modal-body">
 							<img style="width: 100%;" src="<?php echo wpsite_psn()->plugin_url() . 'img/please-moderate.png'; ?>"/>
 						</div>
 						<div class="modal-footer">
-							<button type="button" class="btn btn-default" data-dismiss="modal"><?php esc_html_e( 'Close', 'wpsite-post-status-notification' ) ?></button>
+							<button type="button" class="btn btn-default" data-dismiss="modal"><?php esc_html_e( 'Close', 'wpsite-post-status-notifications' ) ?></button>
 						</div>
 					</div>
 				</div>

--- a/admin/header.php
+++ b/admin/header.php
@@ -5,12 +5,12 @@
 	<div class="nnr-logo"></div>
 
 	<div class="nnr-product-details">
-		<span class="nnr-product-name"><?php esc_html_e( 'Post Status Notifications', 'wpsite-post-status-notification' ) ?></span>
+		<span class="nnr-product-name"><?php esc_html_e( 'Post Status Notifications', 'wpsite-post-status-notifications' ) ?></span>
 		<span class="nnr-product-version"><?php echo wpsite_psn()->get_version() ?></span>
 	</div>
 
 	<a href="http://draftpress.com/products" target="_blank">
-		<button class="nnr-header-button pull-right"><?php esc_html_e( 'More Products', 'wpsite-post-status-notification' ) ?></button>
+		<button class="nnr-header-button pull-right"><?php esc_html_e( 'More Products', 'wpsite-post-status-notifications' ) ?></button>
 	</a>
 
 </div>

--- a/admin/sidebar.php
+++ b/admin/sidebar.php
@@ -2,7 +2,7 @@
 
 	<div class="panel panel-default">
 		<div class="panel-heading">
-			<h3 class="panel-title"><?php esc_html_e( 'Signup now to get notified of plugin updates, awesome themes, and more. Over 10,000+ already have:', 'wpsite-post-status-notification' ) ?></h3>
+			<h3 class="panel-title"><?php esc_html_e( 'Signup now to get notified of plugin updates, awesome themes, and more. Over 10,000+ already have:', 'wpsite-post-status-notifications' ) ?></h3>
 		</div>
 		<div class="panel-body">
 			<!-- Begin MailChimp Signup Form -->
@@ -20,14 +20,14 @@
 			<form action="//wpsite.us5.list-manage.com/subscribe/post?u=82c2341134bbdc37714642adb&amp;id=642b18616e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate style="padding-left: 0;">
 				<div id="mc_embed_signup_scroll">
 					<div style="margin-bottom: 20px;">
-						<input type="email" value="" name="EMAIL" class="required email form-control" id="mce-EMAIL" placeholder="<?php esc_html_e( 'Email Address', 'wpsite-post-status-notification' ) ?>">
+						<input type="email" value="" name="EMAIL" class="required email form-control" id="mce-EMAIL" placeholder="<?php esc_html_e( 'Email Address', 'wpsite-post-status-notifications' ) ?>">
 					</div>
 					<div id="mce-responses" class="clear">
 						<div class="response" id="mce-error-response" style="display:none"></div>
 						<div class="response" id="mce-success-response" style="display:none"></div>
 					</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
 					<div style="position: absolute; left: -5000px;"><input type="text" name="b_82c2341134bbdc37714642adb_642b18616e" tabindex="-1" value=""></div>
-					<div><input style="width:100%;" type="submit" value="Subscribe" name="subscribe" class="btn btn-default"></div>
+					<div><input style="width:100%;" type="submit" value="<?php esc_attr_e( 'Subscribe', 'wpsite-post-status-notifications' ) ?>" name="subscribe" class="btn btn-default"></div>
 				</div>
 			</form>
 			</div>
@@ -38,18 +38,18 @@
 
 	<div class="panel panel-default">
 		<div class="panel-heading">
-			<h3 class="panel-title"><?php esc_html_e( 'Must-Read Articles', 'wpsite-post-status-notification' ) ?></h3>
+			<h3 class="panel-title"><?php esc_html_e( 'Must-Read Articles', 'wpsite-post-status-notifications' ) ?></h3>
 		</div>
 		<div class="panel-body">
 			<div class="wpsite_feed">
-				<script src="http://feeds.feedburner.com/99robots?format=sigpro" type="text/javascript" ></script><noscript><p><?php esc_html_e( 'Subscribe to 99 Robots Feed:', 'wpsite-post-status-notification' ) ?> <a href="http://feeds.feedburner.com/99robots"></a><br/><?php esc_html_e( 'Powered by FeedBurner', 'wpsite-post-status-notification' ) ?></p> </noscript>
+				<script src="http://feeds.feedburner.com/99robots?format=sigpro" type="text/javascript" ></script><noscript><p><?php esc_html_e( 'Subscribe to 99 Robots Feed:', 'wpsite-post-status-notifications' ) ?> <a href="http://feeds.feedburner.com/99robots"></a><br/><?php esc_html_e( 'Powered by FeedBurner', 'wpsite-post-status-notifications' ) ?></p> </noscript>
 			</div>
 		</div>
 	</div>
 
 	<div class="panel panel-default">
 		<div class="panel-heading">
-			<h3 class="panel-title"><?php esc_html_e( 'Need a Plugin or Theme Developed?', 'wpsite-post-status-notification' ) ?></h3>
+			<h3 class="panel-title"><?php esc_html_e( 'Need a Plugin or Theme Developed?', 'wpsite-post-status-notifications' ) ?></h3>
 		</div>
 		<div class="panel-body">
 			<a class="nnr-sidebar-image-link" href="https://draftpress.com/contact?utm_medium=sidebar&utm_campaign=plugin-request-banner" target="_blank">

--- a/wpsite-post-status-notification.php
+++ b/wpsite-post-status-notification.php
@@ -143,7 +143,7 @@ class WPSite_Post_Status_Notifications
      */
     public function __clone()
     {
-        wc_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'wpsite-post-status-notification' ), $this->version );
+        wc_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'wpsite-post-status-notifications' ), $this->version );
     }
 
     /**
@@ -151,7 +151,7 @@ class WPSite_Post_Status_Notifications
      */
     public function __wakeup()
     {
-        wc_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'wpsite-post-status-notification' ), $this->version );
+        wc_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'wpsite-post-status-notifications' ), $this->version );
     }
 
     /**
@@ -205,15 +205,15 @@ class WPSite_Post_Status_Notifications
     public function load_plugin_textdomain()
     {
 
-        $locale = apply_filters( 'plugin_locale', get_locale(), 'wpsite-post-status-notification' );
+        $locale = apply_filters( 'plugin_locale', get_locale(), 'wpsite-post-status-notifications' );
 
         load_textdomain(
-            'wpsite-post-status-notification',
+            'wpsite-post-status-notifications',
             WP_LANG_DIR . '/wpsite-post-status-notification/wpsite-post-status-notification-' . $locale . '.mo'
         );
 
         load_plugin_textdomain(
-            'wpsite-post-status-notification',
+            'wpsite-post-status-notifications',
             false,
             $this->plugin_dir() . '/languages/'
         );
@@ -245,8 +245,8 @@ class WPSite_Post_Status_Notifications
 
         $settings_page_load = add_submenu_page(
             'options-general.php',
-            esc_html__( 'Post Status Notifications', 'wpsite-post-status-notification' ),
-            esc_html__( 'Post Status Notifications', 'wpsite-post-status-notification' ),
+            esc_html_x( 'Post Status Notifications', 'Menu Item and Page Title', 'wpsite-post-status-notifications' ),
+            esc_html_x( 'Post Status Notifications', 'Menu Item and Page Title', 'wpsite-post-status-notifications' ),
             'manage_options',
             self::$settings_page,
             array( $this, 'page_settings' )

--- a/wpsite-post-status-notification.php
+++ b/wpsite-post-status-notification.php
@@ -209,7 +209,7 @@ class WPSite_Post_Status_Notifications
 
         load_textdomain(
             'wpsite-post-status-notifications',
-            WP_LANG_DIR . '/wpsite-post-status-notification/wpsite-post-status-notification-' . $locale . '.mo'
+            WP_LANG_DIR . '/wpsite-post-status-notifications/wpsite-post-status-notifications-' . $locale . '.mo'
         );
 
         load_plugin_textdomain(
@@ -227,7 +227,7 @@ class WPSite_Post_Status_Notifications
     public function plugin_links( $links )
     {
 
-        $settings_link = '<a href="options-general.php?page=' . self::$settings_page . '">Settings</a>';
+        $settings_link = '<a href="options-general.php?page=' . self::$settings_page . '">' . esc_html__( 'Settings', 'wpsite-post-status-notifications' ) . '</a>';
         array_unshift( $links, $settings_link );
 
         return $links;


### PR DESCRIPTION
- The current text domain used in the codes is `wpsite-post-status-notification` but the correct text domain is `wpsite-post-status-notifications`. Plugin's text domain must be equal to its owned slug `wpsite-post-status-notifications`, and **should not** be a typo (missing **s**). This means even if this plugin's GlotPress locale project is done, this plugin still display localized UI strings incorrectly.
- This PR fixed this issue.